### PR TITLE
fix(HTTPHandler): do not parse body if value is  None

### DIFF
--- a/lambda_handlers/handlers/http_handler.py
+++ b/lambda_handlers/handlers/http_handler.py
@@ -54,7 +54,7 @@ class HTTPHandler(EventHandler):
 
     def format_input(self, event):
         """Return `event` with a formatted `event['body']`."""
-        if 'body' in event:
+        if 'body' in event and event['body']:
             try:
                 event['body'] = self._input_format.format(event['body'])
             except FormatError as error:

--- a/lambda_handlers/handlers/tests/test_http_handler.py
+++ b/lambda_handlers/handlers/tests/test_http_handler.py
@@ -20,6 +20,11 @@ class TestHTTPHandlerDefaults:
         assert isinstance(response, dict)
         assert response['statusCode'] == 200
 
+    def test_none_body_validation(self, handler):
+        response = handler({'body': None}, None)
+        assert isinstance(response, dict)
+        assert response['statusCode'] == 200
+
     def test_invalid_body_validation(self, handler):
         response = handler({'body': '{.x'}, None)
         assert isinstance(response, dict)


### PR DESCRIPTION
# Description

HTTPHandler will not attempt to the parse body value to JSON if the value is `None`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
